### PR TITLE
Handle Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/masteratul/rn/testexception/RnTestExceptionHandlerPackage.java
+++ b/android/src/main/java/com/masteratul/rn/testexception/RnTestExceptionHandlerPackage.java
@@ -16,7 +16,7 @@ public class RnTestExceptionHandlerPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RnTestExceptionHandlerModule(reactContext));
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Fixes an Android compile failure due to an API change in React Native 0.47+.