### PR TITLE
Add homepage attribute to podspec

### DIFF
--- a/ios/RnTestExceptionHandler.podspec
+++ b/ios/RnTestExceptionHandler.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RnTestExceptionHandler
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/master-atul/rn-test-exception-handler"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Receiving the following error on `pod install`:
Fetching podspec for `RnTestExceptionHandler` from `../node_modules/rn-test-exception-handler/ios`
[!] The `RnTestExceptionHandler` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.